### PR TITLE
Adds support for Azure DevOps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@octokit/core": "^3.6.0",
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.6.2",
+        "azure-devops-node-api": "^11.1.1",
         "lodash": "^4.17.21",
         "node-stream-zip": "^1.15.0",
         "optional-typescript": "^1.6.0",
@@ -21,6 +22,9 @@
         "tslib": "^2.3.1",
         "typescript-ioc": "^3.2.2",
         "yargs": "^17.5.1"
+      },
+      "bin": {
+        "gitu": "dist/script.js"
       },
       "devDependencies": {
         "@babel/core": "^7.16.0",
@@ -2518,6 +2522,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.1.1.tgz",
+      "integrity": "sha512-XDG91XzLZ15reP12s3jFkKS8oiagSICjnLwxEYieme4+4h3ZveFOFRA4iYIG40RyHXsiI0mefFYYMFIJbMpWcg==",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
     },
     "node_modules/babel-jest": {
       "version": "27.3.1",
@@ -5804,6 +5817,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -5837,6 +5858,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -5868,6 +5899,11 @@
         "lodash.set": "^4.3.2",
         "reflect-metadata": "^0.1.13"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -8028,6 +8064,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "azure-devops-node-api": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.1.1.tgz",
+      "integrity": "sha512-XDG91XzLZ15reP12s3jFkKS8oiagSICjnLwxEYieme4+4h3ZveFOFRA4iYIG40RyHXsiI0mefFYYMFIJbMpWcg==",
+      "requires": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
     },
     "babel-jest": {
       "version": "27.3.1",
@@ -10530,6 +10575,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -10550,6 +10600,16 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
+    },
+    "typed-rest-client": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+      "requires": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -10575,6 +10635,11 @@
         "lodash.set": "^4.3.2",
         "reflect-metadata": "^0.1.13"
       }
+    },
+    "underscore": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@octokit/core": "^3.6.0",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.6.2",
+    "azure-devops-node-api": "^11.1.1",
     "lodash": "^4.17.21",
     "node-stream-zip": "^1.15.0",
     "optional-typescript": "^1.6.0",

--- a/src/lib/azure-devops/azure-devops.ts
+++ b/src/lib/azure-devops/azure-devops.ts
@@ -1,0 +1,408 @@
+import {getPersonalAccessTokenHandler, WebApi} from 'azure-devops-node-api';
+import {IGitApi} from 'azure-devops-node-api/GitApi';
+import {
+  GitCommitRef,
+  GitPullRequestMergeStrategy, GitQueryCommitsCriteria,
+  ItemContentType,
+  PullRequestAsyncStatus,
+  PullRequestStatus,
+  VersionControlChangeType
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import {get, post} from 'superagent';
+
+import {GitBase} from '../git.base';
+import {
+  CreatePullRequestOptions,
+  CreateRepoOptions,
+  CreateWebhook,
+  DeleteBranchOptions,
+  GetPullRequestOptions,
+  GitApi,
+  GitBranch,
+  GitEvent,
+  GitHeader, MergeConflict,
+  MergeMethod,
+  MergePullRequestOptions,
+  PullRequest,
+  UpdatePullRequestBranchOptions
+} from '../git.api';
+import {GitHookUrlVerification, GitRepo, TypedGitRepoConfig, Webhook} from '../git.model';
+import {EvaluateErrorForRetry} from '../../util/retry-with-delay';
+import first from '../../util/first';
+import sleep from '../../util/sleep';
+
+interface AzureTypedGitRepoConfig extends TypedGitRepoConfig {
+  project?: string;
+}
+
+const mapMergeStatus = (status: PullRequestAsyncStatus): string => {
+  switch (status) {
+    case PullRequestAsyncStatus.Conflicts:
+      return 'conflicts'
+    case PullRequestAsyncStatus.Failure:
+      return 'failure'
+    case PullRequestAsyncStatus.NotSet:
+      return 'notSet'
+    case PullRequestAsyncStatus.Queued:
+      return 'queued'
+    case PullRequestAsyncStatus.RejectedByPolicy:
+      return 'rejectedByPolicy'
+    case PullRequestAsyncStatus.Succeeded:
+      return 'succeeded'
+  }
+}
+
+const mapMergeMethod = (method: MergeMethod): GitPullRequestMergeStrategy => {
+  switch (method) {
+    case 'merge':
+      return GitPullRequestMergeStrategy.RebaseMerge
+    case 'rebase':
+      return GitPullRequestMergeStrategy.Rebase
+    case 'squash':
+      return GitPullRequestMergeStrategy.Squash
+    default:
+      throw new Error(`Unknown merge method: ${method}`)
+  }
+}
+
+export class AzureDevops extends GitBase<AzureTypedGitRepoConfig> implements GitApi<AzureTypedGitRepoConfig> {
+  constructor(config: AzureTypedGitRepoConfig) {
+    super(config);
+  }
+
+  get project() {
+    return this.config.project
+  }
+
+  async getGitApi(): Promise<IGitApi> {
+    const orgUrl = `https://${this.host}/${this.owner}`;
+
+    const authHandler = getPersonalAccessTokenHandler(this.password);
+    const connection = new WebApi(orgUrl, authHandler);
+
+    return connection.getGitApi(orgUrl);
+  }
+
+  async createRepo({name, privateRepo = false, autoInit = true}: CreateRepoOptions): Promise<GitApi> {
+    const api = await this.getGitApi()
+
+    const gitApi: AzureDevops = await api
+      .createRepository({name}, this.project)
+      .then(result => this.getRepoApi({repo: name, url: result.remoteUrl}) as AzureDevops)
+
+    if (autoInit) {
+      this.logger.debug('Initializing repo')
+      await gitApi.createFile('README.md', `# ${name}`, 'Initial commit').catch(err => this.logger.debug('Error:', err))
+    }
+
+    return gitApi
+  }
+
+  async createFile(path: string, content: string, comment?: string, branch?: string): Promise<GitApi> {
+    const api = await this.getGitApi()
+
+    if (!branch) {
+      branch = await api
+        .getRepository(this.repo, this.project)
+        .then(res => res.defaultBranch || 'main')
+    }
+
+    if (!comment) {
+      comment = `Adds file: ${path}`
+    }
+
+    const oldObjectId = await api
+      .getCommits(
+        this.repo,
+        {
+          itemVersion: {
+            version: branch
+          },
+          showOldestCommitsFirst: false,
+          $top: 1
+        },
+        this.project
+      )
+      .then(res => first(res)
+        .map(commit => commit.commitId)
+        .valueOr('0000000000000000000000000000000000000000')
+      )
+      .catch(err => '0000000000000000000000000000000000000000')
+
+    await api.createPush(
+      {
+        refUpdates: [{
+          name: `refs/heads/${branch}`,
+          oldObjectId
+        }],
+        commits: [{
+          comment,
+          changes: [{
+            changeType: VersionControlChangeType.Add,
+            item: {
+              path
+            },
+            newContent: {
+              content,
+              contentType: ItemContentType.RawText
+            }
+          }]
+        }]
+      },
+      this.repo,
+      this.project
+    )
+
+    return this
+  }
+
+  async deleteRepo(): Promise<GitApi> {
+    const api = await this.getGitApi()
+
+    const repoInfo: GitRepo = await this.getRepoInfo();
+
+    return await api
+      .deleteRepository(repoInfo.id, this.project)
+      .then(() => {
+        const url = this.url.replace(new RegExp('(.*)/.*', 'g'), '$1')
+
+        return this.getRepoApi({url})
+      })
+  }
+
+  async getRepoInfo(): Promise<GitRepo> {
+    const api = await this.getGitApi()
+
+    const extractSlug = (remoteUrl: string) => {
+      return remoteUrl.replace(`https://${this.host}/`, '')
+    }
+
+    return await api
+      .getRepository(this.repo, this.project)
+      .then(result => ({
+        id: result.id,
+        slug: extractSlug(result.remoteUrl),
+        name: result.name,
+        description: '',
+        is_private: false
+      }))
+  }
+
+  async createPullRequest({title, sourceBranch, targetBranch, draft, issue, maintainer_can_modify}: CreatePullRequestOptions, retryHandler?: EvaluateErrorForRetry): Promise<PullRequest> {
+    const api = await this.getGitApi()
+
+    return api
+      .createPullRequest(
+        {
+          isDraft: draft,
+          sourceRefName: `refs/heads/${sourceBranch}`,
+          targetRefName: `refs/heads/${targetBranch}`,
+          title,
+        },
+        this.repo,
+        this.project
+      )
+      .then(res => ({
+        pullNumber: res.pullRequestId,
+        sourceBranch,
+        targetBranch,
+        mergeStatus: mapMergeStatus(res.mergeStatus),
+        hasConflicts: false,
+      }))
+  }
+
+  async deleteBranch(options: DeleteBranchOptions): Promise<string> {
+    throw new Error('Not implemented: deleteBranch')
+  }
+
+  async getBranches(): Promise<GitBranch[]> {
+    const api = await this.getGitApi()
+
+    return api
+      .getBranches(this.repo, this.project)
+      .then(result => result.map(ref => ({
+        name: ref.name
+      })))
+  }
+
+  async getDefaultBranch(): Promise<string> {
+    const api = await this.getGitApi()
+
+    return await api
+      .getRepository(this.repo, this.project)
+      .then(result => result.defaultBranch)
+  }
+
+  async getPullRequest({pullNumber}: GetPullRequestOptions, retryHandler?: EvaluateErrorForRetry): Promise<PullRequest> {
+    const api = await this.getGitApi()
+
+    return api
+      .getPullRequest(this.repo, pullNumber, this.project)
+      .then(result => ({
+        pullNumber,
+        sourceBranch: result.sourceRefName.replace('refs/heads/', ''),
+        targetBranch: result.targetRefName.replace('refs/heads/', ''),
+        mergeStatus: mapMergeStatus(result.mergeStatus),
+        hasConflicts: result.mergeStatus === PullRequestAsyncStatus.Conflicts
+      }))
+  }
+
+  async mergePullRequestInternal({pullNumber, method, title, message, delete_branch_after_merge}: MergePullRequestOptions): Promise<string> {
+    const api = await this.getGitApi()
+
+    const lastMergeSourceCommit = await api
+      .getPullRequest(this.repo, pullNumber, this.project)
+      .then(result => result.lastMergeSourceCommit.commitId)
+
+    return api
+      .updatePullRequest(
+        {
+          lastMergeSourceCommit: {
+            commitId: lastMergeSourceCommit
+          },
+          completionOptions: {
+            bypassPolicy: true,
+            mergeStrategy: mapMergeMethod(method),
+            deleteSourceBranch: delete_branch_after_merge,
+          },
+          status: PullRequestStatus.Completed
+        },
+        this.repo,
+        pullNumber,
+        this.project
+      )
+      .then(async result => {
+        // sleep here to prevent a timing issue between the pull request and pull request conflict apis
+        await sleep(500)
+
+        const conflicts = await api.getPullRequestConflicts(this.repo, pullNumber, this.project)
+
+        if (conflicts.length > 0) {
+          throw new MergeConflict(pullNumber)
+        }
+
+        return result.mergeId
+      })
+      .catch(err => {
+        this.logger.debug('Error merging pull request: ', err)
+        throw err
+      })
+  }
+
+  async updatePullRequestBranch(options: UpdatePullRequestBranchOptions, retryHandler?: EvaluateErrorForRetry): Promise<string> {
+    const {sourceBranch, targetBranch} = await this.getPullRequest(options)
+
+    return this
+      .rebaseBranch({sourceBranch, targetBranch})
+      .then(() => 'Updated')
+  }
+
+  async getWebhooks(): Promise<Webhook[]> {
+    const api = await this.getGitApi()
+
+    const {repository} =  await api
+      .getRepository(this.repo, this.project)
+      .then(result => ({
+        repository: result.id
+      }))
+
+    const matchRepository = (repo: string) => {
+      return (hook): boolean => hook.publisherInputs?.repository === repo
+    }
+
+    const azureSubscriptionToWebhook = (hook): Webhook => {
+      return {
+        id: hook.id,
+        name: hook.eventDescription,
+        active: hook.status === 'enabled',
+        events: [hook.eventType],
+        config: {
+          content_type: 'json',
+          url: hook.consumerInputs.url,
+          insecure_ssl: (hook.consumerInputs.acceptUntrustedCerts == 'true' ? GitHookUrlVerification.performed : GitHookUrlVerification.notPerformed) as any
+        }
+      }
+    }
+
+    return get(`https://${this.host}/${this.owner}/_apis/hooks/subscriptions?api-version=6.0`)
+      .auth(this.username, this.password)
+      .then(res => res.body.value
+        .filter(matchRepository(repository))
+        .map(azureSubscriptionToWebhook)
+      )
+  }
+
+  async createWebhook({webhookUrl}: CreateWebhook): Promise<string> {
+    const api = await this.getGitApi()
+
+    const {projectId, repository} =  await api
+      .getRepository(this.repo, this.project)
+      .then(result => ({
+        projectId: result.project.id,
+        repository: result.id
+      }))
+
+    return post(`https://${this.host}/${this.owner}/_apis/hooks/subscriptions?api-version=6.0`)
+      .auth(this.username, this.password)
+      .send({
+        publisherId: 'tfs',
+        resourceVersion: '1.0',
+        eventType: 'git.push',
+        eventDescription: `Push to ${this.repo}`,
+        consumerId: 'webHooks',
+        consumerActionId: 'httpRequest',
+        actionDescription: `To url ${webhookUrl}`,
+        publisherInputs: {
+          branch: '',
+          pushedBy: '',
+          projectId,
+          repository
+        },
+        consumerInputs: {
+          url: webhookUrl
+        }
+      })
+      .then(res => res.body.id)
+  }
+
+  getEventName(eventId: GitEvent): string {
+    switch (eventId) {
+      case GitEvent.PUSH:
+        return 'git.push'
+      default:
+        throw new Error('Unknown event type: ' + eventId)
+    }
+  }
+
+  async getFileContents(fileDescriptor: { path: string; url?: string }): Promise<string | Buffer> {
+    return Promise.resolve(undefined);
+  }
+
+  getHeader(headerId: GitHeader): string {
+    return '';
+  }
+
+  getRef(): string {
+    return '';
+  }
+
+  getRefPath(): string {
+    return '';
+  }
+
+  getRepositoryNamePath(): string {
+    return '';
+  }
+
+  getRepositoryUrlPath(): string {
+    return '';
+  }
+
+  getRevisionPath(): string {
+    return '';
+  }
+
+  async listFiles(): Promise<Array<{ path: string; url?: string }>> {
+    return Promise.resolve(undefined);
+  }
+}

--- a/src/lib/azure-devops/index.ts
+++ b/src/lib/azure-devops/index.ts
@@ -1,0 +1,1 @@
+export * from './azure-devops'

--- a/src/lib/bitbucket/index.ts
+++ b/src/lib/bitbucket/index.ts
@@ -63,10 +63,6 @@ export class Bitbucket extends GitBase implements GitApi {
     super(config);
   }
 
-  getConfig(): TypedGitRepoConfig {
-    return this.config
-  }
-
   getBaseUrl(): string {
     return `${this.config.protocol}://api.bitbucket.org/2.0`;
   }
@@ -302,12 +298,6 @@ export class Bitbucket extends GitBase implements GitApi {
     return this;
   }
 
-  getRepoApi({repo, url}: { repo?: string, url: string }): GitApi {
-    const newConfig = Object.assign({}, this.config, {repo, url})
-
-    return apiFromConfig(newConfig)
-  }
-
   deleteRepo(): Promise<GitApi> {
     return deleteUrl(this.getRepoUrl())
       .auth(this.config.username, this.config.password)
@@ -333,6 +323,7 @@ export class Bitbucket extends GitBase implements GitApi {
       .set('User-Agent', `${this.config.username} via ibm-garage-cloud cli`)
       .accept('application/json')
       .then(res => ({
+        id: res.body.id,
         slug: res.body.full_name,
         name: res.body.name,
         description: res.body.description,

--- a/src/lib/git.api.ts
+++ b/src/lib/git.api.ts
@@ -1,4 +1,4 @@
-import {SimpleGit, SimpleGitOptions} from 'simple-git';
+import {SimpleGit} from 'simple-git';
 
 import {GitHost, GitRepo, TypedGitRepoConfig, Webhook} from './git.model';
 import {EvaluateErrorForRetry} from '../util/retry-with-delay';
@@ -99,9 +99,11 @@ export class UnresolvedConflictsError extends Error {
 
 export type MergeResolver = (git: SimpleGitWithApi, conflicts: string[]) => Promise<{resolvedConflicts: string[], conflictErrors?: Error[]}>;
 
+export type MergeMethod = 'merge' | 'squash' | 'rebase'
+
 export interface MergePullRequestOptions extends BaseOptions {
   pullNumber: number;
-  method: 'merge' | 'squash' | 'rebase';
+  method: MergeMethod;
   resolver?: MergeResolver;
   title?: string;
   message?: string;
@@ -178,10 +180,10 @@ export interface CreateRepoOptions {
   privateRepo?: boolean;
 }
 
-export abstract class GitApi extends LocalGitApi {
+export abstract class GitApi<T extends TypedGitRepoConfig = TypedGitRepoConfig> extends LocalGitApi {
   abstract getType(): GitHost;
 
-  abstract getConfig(): TypedGitRepoConfig;
+  abstract getConfig(): T;
 
   abstract getWebhooks(): Promise<Webhook[]>;
 

--- a/src/lib/git.model.ts
+++ b/src/lib/git.model.ts
@@ -5,7 +5,8 @@ export enum GitHost {
   ghe = 'GHE',
   gogs = 'Gogs',
   bitbucket = 'Bitbucket',
-  gitea = 'Gitea'
+  gitea = 'Gitea',
+  azure = 'Azure DevOps'
 }
 
 export interface GitLocalRepoConfig {
@@ -75,6 +76,7 @@ export interface Webhook {
 }
 
 export interface GitRepo {
+  id: string;
   slug: string;
   name: string;
   description: string;

--- a/src/lib/git.xspec.ts
+++ b/src/lib/git.xspec.ts
@@ -12,6 +12,7 @@ interface CaseConfig {
   org: string;
   username: string;
   password: string;
+  project?: string;
 }
 
 const getConfigValues = (name: string): CaseConfig | undefined => {
@@ -20,6 +21,7 @@ const getConfigValues = (name: string): CaseConfig | undefined => {
   const org = process.env[asKey(name, 'org')];
   const username = process.env[asKey(name, 'username')];
   const password = process.env[asKey(name, 'password')];
+  const project = process.env[asKey(name, 'project')];
 
   if (skip === 'true') {
     console.log(`${asKey(name, 'skip')} is set to true. Skipping test...`)
@@ -36,7 +38,8 @@ const getConfigValues = (name: string): CaseConfig | undefined => {
     baseUrl,
     org,
     username,
-    password
+    password,
+    project
   }
 }
 
@@ -59,6 +62,7 @@ addTestConfig('ghe');
 addTestConfig('gitlab');
 addTestConfig('gitea');
 addTestConfig('bitbucket');
+addTestConfig('azure');
 
 function makeId(length: number): string {
   const result           = [];
@@ -74,7 +78,7 @@ function makeId(length: number): string {
 
 const describeTestCases = describe.each<CaseConfig>(cases);
 
-describeTestCases('given $name', ({name, baseUrl, org, username, password} : CaseConfig) => {
+describeTestCases('given $name', ({name, baseUrl, org, username, password, project} : CaseConfig) => {
   test('canary verifies test infrastructure', () => {
     expect(true).toBe(true);
   });
@@ -82,7 +86,7 @@ describeTestCases('given $name', ({name, baseUrl, org, username, password} : Cas
   let classUnderTest: GitApi;
   let repo: string;
   beforeAll(async () => {
-    const url = `${baseUrl}/${org}`
+    const url = project ? `${baseUrl}/${org}/${project}` : `${baseUrl}/${org}`
     classUnderTest = await apiFromUrl(url, {username, password})
 
     repo = `test-${makeId(10)}`
@@ -99,6 +103,8 @@ describeTestCases('given $name', ({name, baseUrl, org, username, password} : Cas
           console.log('Got repo: ', repoApi.getConfig().repo)
 
           const repoInfo: GitRepo = await repoApi.getRepoInfo()
+
+          console.log('Repo url: ' + repoApi.getConfig().url)
 
           expect(repoInfo.name).toEqual(repo)
 

--- a/src/lib/gitea/index.ts
+++ b/src/lib/gitea/index.ts
@@ -330,12 +330,6 @@ export class Gitea extends GitBase implements GitApi {
     return GiteaEvent[eventId];
   }
 
-  getRepoApi({repo, url}: {repo?: string, url: string}): GitApi {
-    const newConfig = Object.assign({}, this.config, {repo, url})
-
-    return apiFromConfig(newConfig)
-  }
-
   async getWebhooks(): Promise<Webhook[]> {
     return get(`${this.getRepoUrl()}/hooks`)
       .auth(this.config.username, this.config.password)
@@ -402,16 +396,13 @@ export class Gitea extends GitBase implements GitApi {
       });
   }
 
-  getConfig(): TypedGitRepoConfig {
-    return this.config
-  }
-
   async getRepoInfo(): Promise<GitRepo> {
     return get(this.getRepoUrl())
       .auth(this.config.username, this.config.password)
       .set('User-Agent', `${this.config.username} via ibm-garage-cloud cli`)
       .accept('application/vnd.github.v3+json')
       .then(res => ({
+        id: res.body.id,
         slug: res.body.full_name,
         name: res.body.name,
         description: res.body.description,

--- a/src/lib/github/github.ts
+++ b/src/lib/github/github.ts
@@ -105,12 +105,6 @@ abstract class GithubCommon extends GitBase implements GitApi {
 
   abstract getRepoUrl(): string;
 
-  getRepoApi({repo, url}: {repo?: string, url: string}): GitApi {
-    const newConfig = Object.assign({}, this.config, {repo, url})
-
-    return apiFromConfig(newConfig)
-  }
-
   async listFiles(): Promise<Array<{path: string, url?: string, contents?: string}>> {
     const response: Response = await this.get(`/git/trees/${this.config.branch}`);
 
@@ -362,6 +356,7 @@ abstract class GithubCommon extends GitBase implements GitApi {
       })
       .then((res: any) => {
         return ({
+          id: res.data.id,
           slug: res.data.full_name,
           name: res.data.name,
           description: res.data.description,
@@ -385,9 +380,6 @@ abstract class GithubCommon extends GitBase implements GitApi {
           Object.assign({}, {owner: this.config.owner, repo: this.config.repo}, this.buildWebhookData(options)) as any
         )
         .then(res => 'test')
-      // const response: Response = await this.post('/hooks', this.buildWebhookData(options));
-      //
-      // return response.body.id;
     } catch (err) {
       if (isResponseError(err)) {
         if (err.response.text.match(/Hook already exists/)) {
@@ -451,10 +443,6 @@ abstract class GithubCommon extends GitBase implements GitApi {
 
   getEventName(eventId: GitEvent): string {
     return GithubEvent[eventId];
-  }
-
-  getConfig(): TypedGitRepoConfig {
-    return this.config
   }
 }
 

--- a/src/lib/gitlab/index.ts
+++ b/src/lib/gitlab/index.ts
@@ -1,19 +1,25 @@
-import {get, put, post, delete as deleteUrl, Response} from 'superagent';
+import {delete as deleteUrl, get, post, put, Response} from 'superagent';
 
 import {
   CreatePullRequestOptions,
   CreateRepoOptions,
-  CreateWebhook, DeleteBranchOptions, GetPullRequestOptions,
-  GitApi, GitBranch,
+  CreateWebhook,
+  DeleteBranchOptions,
+  GetPullRequestOptions,
+  GitApi,
+  GitBranch,
   GitEvent,
-  GitHeader, MergeConflict, MergePullRequestOptions, PullRequest,
-  UnknownWebhookError, UpdatePullRequestBranchOptions,
+  GitHeader,
+  MergeConflict,
+  MergePullRequestOptions,
+  PullRequest,
+  UnknownWebhookError,
+  UpdatePullRequestBranchOptions,
   WebhookAlreadyExists
 } from '../git.api';
 import {GitBase} from '../git.base';
-import {GitRepo, RepoNotFound, TypedGitRepoConfig, UserNotFound, Webhook} from '../git.model';
+import {GitRepo, RepoNotFound, TypedGitRepoConfig, Webhook} from '../git.model';
 import {isResponseError} from '../../util/superagent-support';
-import {apiFromConfig} from '../util';
 import first from '../../util/first';
 import sleep from '../../util/sleep';
 
@@ -79,10 +85,6 @@ export class Gitlab extends GitBase implements GitApi {
 
   constructor(config: TypedGitRepoConfig) {
     super(config);
-  }
-
-  getConfig(): TypedGitRepoConfig {
-    return this.config
   }
 
   getBaseUrl(): string {
@@ -383,18 +385,13 @@ export class Gitlab extends GitBase implements GitApi {
       })
   }
 
-  getRepoApi({repo, url}: {repo?: string, url: string}): GitApi {
-    const newConfig = Object.assign({}, this.config, {repo, url})
-
-    return apiFromConfig(newConfig)
-  }
-
   async getRepoInfo(): Promise<GitRepo> {
     return get(this.getRepoUrl())
       .set('Private-Token', this.config.password)
       .set('User-Agent', `${this.config.username} via ibm-garage-cloud cli`)
       .accept('application/json')
       .then(res => ({
+        id: res.body.id,
         slug: res.body.path_with_namespace,
         name: res.body.path,
         description: res.body.description,

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -8,6 +8,7 @@ import {Gogs} from './gogs';
 import {Gitea} from './gitea';
 import {Bitbucket} from './bitbucket';
 import {GitApi} from './git.api';
+import {AzureDevops} from './azure-devops';
 
 const GIT_URL_PATTERNS = {
   'http': '(https{0,1})://([^/]*)/([^/]*)/{0,1}([^#]*)#{0,1}(.*)',
@@ -20,7 +21,8 @@ const API_FACTORIES = [
   {key: GitHost.gitlab, value: Gitlab},
   {key: GitHost.gogs, value: Gogs},
   {key: GitHost.bitbucket, value: Bitbucket},
-  {key: GitHost.gitea, value: Gitea}
+  {key: GitHost.gitea, value: Gitea},
+  {key: GitHost.azure, value: AzureDevops}
 ].reduce((result: {[key: string]: any}, current: {key: GitHost, value: any}) => {
   result[current.key] = current.value;
 
@@ -45,36 +47,72 @@ export function apiFromConfig(config: TypedGitRepoConfig): GitApi {
 }
 
 export async function gitRepoConfigFromUrl(repoUrl: string, credentials: {username: string, password: string}, branch = 'master'): Promise<TypedGitRepoConfig> {
-  const config: AuthGitRepoConfig = Object.assign({}, parseGitUrl(repoUrl), _.pick(credentials, ['username', 'password']), {branch}) as any;
+  const originalConfig: AuthGitRepoConfig = Object.assign({}, parseGitUrl(repoUrl), _.pick(credentials, ['username', 'password']), {branch}) as any;
 
-  const type: GitHost = await getGitRepoType(config);
+  const {type, config} = await getGitRepoType(originalConfig);
 
   return Object.assign({}, config, {type}) as any;
 }
 
-async function getGitRepoType(config: AuthGitRepoConfig): Promise<GitHost> {
+type RepoTypeResultBuilderType = (gitHost: GitHost, config?: AuthGitRepoConfig) => RepoTypeResult
+
+const repoTypeResultBuilder = (config: AuthGitRepoConfig): RepoTypeResultBuilderType => {
+  return (type: GitHost, updatedConfig: AuthGitRepoConfig) => {
+    return {config: updatedConfig || config, type}
+  }
+}
+
+interface RepoTypeResult {
+  type: GitHost;
+  config: AuthGitRepoConfig;
+}
+
+const updateAzureRepoConfig = (config: AuthGitRepoConfig): AuthGitRepoConfig => {
+  if (!config.repo) {
+    return config
+  }
+
+  const azureRegex = new RegExp('([^/]+)/_git/(.*)')
+  const result = azureRegex.exec(config.repo)
+  if (result && result.length > 2) {
+    const project: string = result[1]
+    const repo: string = result[2]
+
+    return Object.assign({}, config, {project, repo})
+  } else {
+    return Object.assign({}, config, {project: config.repo, repo: undefined})
+  }
+}
+
+async function getGitRepoType(config: AuthGitRepoConfig): Promise<RepoTypeResult> {
+  const builder: RepoTypeResultBuilderType = repoTypeResultBuilder(config)
+
   if (config.host === 'github.com') {
-    return GitHost.github;
+    return builder(GitHost.github);
   }
 
   if (config.host === 'bitbucket.org') {
-    return GitHost.bitbucket;
+    return builder(GitHost.bitbucket);
+  }
+
+  if (config.host === 'dev.azure.com') {
+    return builder(GitHost.azure, updateAzureRepoConfig(config));
   }
 
   if (await hasHeader(`${config.protocol}://${config.host}/api/v3`, 'X-GitHub-Enterprise-Version', config)) {
-    return GitHost.ghe;
+    return builder(GitHost.ghe);
   }
 
   if (await hasBody(`${config.protocol}://${config.host}/api/v4/projects`, config)) {
-    return GitHost.gitlab;
+    return builder(GitHost.gitlab);
   }
 
   if (await hasBody(`${config.protocol}://${config.host}/api/v1/settings/api`, config)) {
-    return GitHost.gitea;
+    return builder(GitHost.gitea);
   }
 
   if (await hasBody(`${config.protocol}://${config.host}/api/v1/users/${config.username}`, config)) {
-    return GitHost.gogs;
+    return builder(GitHost.gogs);
   }
 
   throw new Error('Unable to identify Git host type: ' + config.url);

--- a/src/util/collection-util.ts
+++ b/src/util/collection-util.ts
@@ -1,0 +1,4 @@
+
+export function isNullOrEmpty<T>(arr: Array<T>) {
+  return !arr || arr.length === 0
+}


### PR DESCRIPTION
- Adds azure-devops api implementation and associated logic to detect azure devops repo - closes #51
- Pulls up `getConfig()` and `getRepoApi()` into GitBase
- Updates `clone()` logic in GitBase to handle git urls from the repos correctly
- Allows for TypedGitRepoConfig to be extended for different repo types (particularly to handle new `project` attribute for azure devops)

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>