### PR TITLE
Fixes error with publicRepo/privateRepo flag on create

### DIFF
--- a/src/lib/github/github.ts
+++ b/src/lib/github/github.ts
@@ -298,7 +298,7 @@ abstract class GithubCommon extends GitBase implements GitApi {
   async createRepo({name, privateRepo = false, autoInit = true}: CreateRepoOptions): Promise<GitApi> {
     const errorHandler = (err) => {
       if (/Bad credentials/.test(err.message)) {
-        throw new BadCredentials('deleteRepo', this.config.type, err)
+        throw new BadCredentials('createRepo', this.config.type, err)
       } else {
         throw err;
       }

--- a/src/util/object-util.ts
+++ b/src/util/object-util.ts
@@ -1,0 +1,8 @@
+
+export const isUndefinedOrNull = (val: any) => {
+  return val === undefined || val === null
+}
+
+export const isDefinedAndNotNull = (val: any) => {
+  return val !== undefined && val !== null
+}


### PR DESCRIPTION
- Configures publicRepo and privateRepo inputs on create to handle --public=false

closes #80

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>