### PR TITLE
Cleans up `exists` command output

### DIFF
--- a/src/commands/exists.ts
+++ b/src/commands/exists.ts
@@ -67,9 +67,6 @@ export const handler =  async (argv: Arguments<ExistsArgs & {debug: boolean}>) =
 
   try {
     const repoApi: GitApi = await apiFromUrl(argv.gitUrl, credentials)
-    if (!argv.quiet) {
-      console.log(`Checking repo: ${argv.gitUrl}`)
-    }
 
     const repoInfo: GitRepo = await repoApi.getRepoInfo()
 

--- a/src/lib/azure-devops/azure-devops.ts
+++ b/src/lib/azure-devops/azure-devops.ts
@@ -182,7 +182,11 @@ export class AzureDevops extends GitBase<AzureTypedGitRepoConfig> implements Git
     const api = await this.getGitApi()
 
     const extractSlug = (remoteUrl: string) => {
-      return remoteUrl.replace(`https://${this.host}/`, '')
+      return remoteUrl.replace(new RegExp(`https://.*${this.host}/`), '')
+    }
+
+    const extractUrl = (remoteUrl: string) => {
+      return `https://${this.host}/${extractSlug(remoteUrl)}`
     }
 
     return await api
@@ -190,6 +194,7 @@ export class AzureDevops extends GitBase<AzureTypedGitRepoConfig> implements Git
       .then(result => ({
         id: result.id,
         slug: extractSlug(result.remoteUrl),
+        http_url: extractUrl(result.remoteUrl),
         name: result.name,
         description: '',
         is_private: false

--- a/src/lib/bitbucket/index.ts
+++ b/src/lib/bitbucket/index.ts
@@ -349,6 +349,7 @@ export class Bitbucket extends GitBase implements GitApi {
       .then(res => ({
         id: res.body.id,
         slug: res.body.full_name,
+        http_url: res.body.links.html.href,
         name: res.body.name,
         description: res.body.description,
         is_private: res.body.is_private

--- a/src/lib/git.model.ts
+++ b/src/lib/git.model.ts
@@ -78,6 +78,7 @@ export interface Webhook {
 export interface GitRepo {
   id: string;
   slug: string;
+  http_url: string;
   name: string;
   description: string;
   is_private: boolean;

--- a/src/lib/gitea/index.ts
+++ b/src/lib/gitea/index.ts
@@ -400,6 +400,7 @@ export class Gitea extends GitBase implements GitApi {
       .then(res => ({
         id: res.body.id,
         slug: res.body.full_name,
+        http_url: res.body.html_url,
         name: res.body.name,
         description: res.body.description,
         is_private: res.body.private

--- a/src/lib/github/github.ts
+++ b/src/lib/github/github.ts
@@ -358,6 +358,7 @@ abstract class GithubCommon extends GitBase implements GitApi {
         return ({
           id: res.data.id,
           slug: res.data.full_name,
+          http_url: res.data.clone_url,
           name: res.data.name,
           description: res.data.description,
           is_private: res.data.private

--- a/src/lib/gitlab/index.ts
+++ b/src/lib/gitlab/index.ts
@@ -403,6 +403,7 @@ export class Gitlab extends GitBase implements GitApi {
       .then(res => ({
         id: res.body.id,
         slug: res.body.path_with_namespace,
+        http_url: res.body.http_url_to_repo,
         name: res.body.path,
         description: res.body.description,
         is_private: res.body.visibility === 'private'


### PR DESCRIPTION
- Removes unnecessary descriptive message
- Adds http_url to output
- Fixes slug output for Azure DevOps repos

closes #87

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>