### PR TITLE
Fixes problem cloning Azure DevOps repos

### DIFF
--- a/src/lib/git.base.ts
+++ b/src/lib/git.base.ts
@@ -59,9 +59,13 @@ export function isMergeError(error: Error): error is ResponseError {
   return false;
 }
 
+const stripGitFromUrl = (url: string): string => {
+  return url.replace(/[.]git$/, '')
+}
+
 const urlWithCredentials = (url: string, credentials: string): string => {
   if (!credentials) {
-    return url
+    return stripGitFromUrl(url)
   }
 
   const urlWithCredentials = new RegExp('(.*://).+@(.*)')
@@ -77,7 +81,7 @@ const urlWithCredentials = (url: string, credentials: string): string => {
       })
   )
 
-  return result.valueOr(url)
+  return stripGitFromUrl(result.valueOr(url))
 }
 
 export abstract class GitBase<T extends TypedGitRepoConfig = TypedGitRepoConfig> extends GitApi<T> {
@@ -160,7 +164,7 @@ export abstract class GitBase<T extends TypedGitRepoConfig = TypedGitRepoConfig>
     const resolver: MergeResolver = config.resolver || (() => Promise.resolve({resolvedConflicts: []}));
 
     try {
-      this.logger.debug(`Cloning ${this.config.host}/${this.config.owner}/${this.config.repo} repo into ${repoDir}`)
+      this.logger.debug(`Cloning ${this.url} repo into ${repoDir}`)
 
       const git: SimpleGitWithApi = await this.clone(repoDir, {userConfig: getUserConfig(options.userConfig)});
 

--- a/src/lib/util.spec.ts
+++ b/src/lib/util.spec.ts
@@ -16,7 +16,7 @@ describe('util', () => {
           host,
           owner,
           repo,
-          url: url + '.git',
+          url,
         });
       });
 
@@ -48,7 +48,7 @@ describe('util', () => {
           host,
           owner,
           repo,
-          url: url + '.git',
+          url: url,
           branch,
         });
       });
@@ -68,7 +68,7 @@ describe('util', () => {
           host,
           owner,
           repo,
-          url: `${protocol}://${host}/${owner}/${repo}.git`,
+          url: `${protocol}://${host}/${owner}/${repo}`,
           username,
           password,
         });
@@ -88,7 +88,7 @@ describe('util', () => {
           host,
           owner,
           repo,
-          url: `${protocol}://${host}/${owner}/${repo}.git`,
+          url: `${protocol}://${host}/${owner}/${repo}`,
           username,
         });
       });

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -193,7 +193,7 @@ export function parseGitUrl(url: string): GitRepoConfig {
 
 function buildGitUrl(protocol: string, host: string, owner: string, repo?: string): string {
   if (repo) {
-    return `${protocol}://${host}/${owner}/${repo}.git`
+    return `${protocol}://${host}/${owner}/${repo}`
   }
 
   return `${protocol}://${host}/${owner}`


### PR DESCRIPTION
- Removes .git from the end of url when cloning - closes #96

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>