### PR TITLE
Fixes issue with create pr on Azure DevOps

### DIFF
--- a/src/commands/support/middleware.ts
+++ b/src/commands/support/middleware.ts
@@ -83,7 +83,11 @@ export const repoNameToGitUrl = () => {
   }
 }
 
-const parseBranchNames = (branchNameString: string): {sourceBranch?: string, targetBranch?: string} => {
+const parseBranchNames = (branchNameString: string, defaultValues: {sourceBranch?: string, targetBranch?: string} = {}): {sourceBranch?: string, targetBranch?: string} => {
+  if (defaultValues.sourceBranch) {
+    return defaultValues
+  }
+
   if (!branchNameString) {
     return {}
   }
@@ -114,7 +118,7 @@ export const parseHostOrgProjectAndBranchFromUrl = () => {
       const branchParts = yargs.gitUrl.split('#')
 
       const gitUrl = branchParts[0];
-      const {sourceBranch, targetBranch} = parseBranchNames(branchParts.length > 1 ? branchParts[1] : '')
+      const {sourceBranch, targetBranch} = parseBranchNames(branchParts.length > 1 ? branchParts[1] : '', yargs)
 
       const result = regex.exec(gitUrl)
 

--- a/src/lib/azure-devops/azure-devops.ts
+++ b/src/lib/azure-devops/azure-devops.ts
@@ -203,7 +203,7 @@ export class AzureDevops extends GitBase<AzureTypedGitRepoConfig> implements Git
         name: result.name,
         description: '',
         is_private: false,
-        default_branch: result.defaultBranch
+        default_branch: result.defaultBranch.replace('refs/heads/', '')
       }))
   }
 


### PR DESCRIPTION
- Removes refs/heads/ from the front of the default branch for Azure DevOps
- Prefers values provided via --sourceBranch and --targetBranch over values provided at end of url

closes #114

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>