### PR TITLE
Adds support for git servers with self-signed certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,17 +111,24 @@ The exposed APIs are defined in `lib/git.api.ts` in the `GitApi` abstract class.
 - `updatePullRequestBranch()` - updates the pull request with the latest from the target branch
 - `clone()` - clones the repository to the local file system
 
-### Command-line
+### Command-line credentials
 
-The library can also be accessed from the command-line as a series of commands. The cli can either be accessed by installing the module globally or by downloading the appropriate binary for your environment. Currently, two commands are available:
+Credentials can be provided to the command-line for each command using the `-u` and `--token` argument OR the credentials can be stored in a configuration file for each host.
 
-#### create repo
+The configuration file is named `.gitu-config` and should be stored in the home directory. Each entry should contain the `host`, `username` and `token`. Optionally, if the git server uses a self-signed certificate it can also be provided to the configuration with the `caCert` value.
 
-`gitu create [repo] -h host -o org -u username`
+For example:
 
-#### delete repo
-
-`gitu delete repoUrl`
+```yaml
+credentials:
+- host: github.com
+  username: myuser
+  token: token
+- host: git.myhost.com
+  username: githuser
+  token: token
+  caCert: /path/to/ca.crt
+```
 
 ## Testing
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -12,6 +12,8 @@ import {
 import {forAzureDevOpsProject, forCredentials} from './support/checks';
 import {isDefinedAndNotNull, isUndefinedOrNull} from '../util/object-util';
 import {Logger, verboseLoggerFactory} from '../util/logger';
+import {defaultBuilder} from './support/builder';
+import {SSLConfig} from './support/model';
 
 const updatePrivateRepo = () => {
   return yargs => {
@@ -40,7 +42,7 @@ const publicPrivateRepo = () => {
 export const command = 'create [name]'
 export const aliases = []
 export const desc = 'Creates a hosted git repo';
-export const builder = (yargs: Argv<any>) => yargs
+export const builder = (yargs: Argv<any>) => defaultBuilder(yargs)
   .positional('name', {
     type: 'string',
     description: 'The name of the repo that will be created',
@@ -116,7 +118,7 @@ export const handler =  async (argv: Arguments<CreateArgs & {debug: boolean, out
 
   Container.bind(Logger).factory(verboseLoggerFactory(argv.debug))
 
-  const credentials = {username: argv.username, password: argv.token}
+  const credentials = {username: argv.username, password: argv.token, caCert: argv.caCert}
 
   try {
     const orgApi: GitApi = argv.gitUrl
@@ -157,7 +159,7 @@ export const handler =  async (argv: Arguments<CreateArgs & {debug: boolean, out
   }
 }
 
-interface CreateArgs {
+interface CreateArgs extends SSLConfig {
   name: string;
   gitUrl?: string;
   host?: string;

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -10,10 +10,12 @@ import {
 import {forAzureDevOpsProject, forCredentials} from './support/checks';
 import {Container} from 'typescript-ioc';
 import {Logger, verboseLoggerFactory} from '../util/logger';
+import {defaultBuilder} from './support/builder';
+import {SSLConfig} from './support/model';
 
 export const command = 'delete [gitUrl]'
 export const desc = 'Deletes a hosted git repo';
-export const builder = (yargs: Argv<any>) => yargs
+export const builder = (yargs: Argv<any>) => defaultBuilder(yargs)
   .positional('gitUrl', {
     type: 'string',
     description: 'The git url of the git repository that will be deleted',
@@ -61,7 +63,7 @@ export const handler =  async (argv: Arguments<DeleteArgs & {debug: boolean}>) =
 
   Container.bind(Logger).factory(verboseLoggerFactory(argv.debug))
 
-  const credentials = {username: argv.username, password: argv.token}
+  const credentials = {username: argv.username, password: argv.token, caCert: argv.caCert}
 
   try {
     const repoApi: GitApi = await apiFromUrl(argv.gitUrl, credentials)
@@ -82,7 +84,7 @@ export const handler =  async (argv: Arguments<DeleteArgs & {debug: boolean}>) =
   }
 }
 
-interface DeleteArgs {
+interface DeleteArgs extends SSLConfig {
   gitUrl: string;
   username: string;
   token: string;

--- a/src/commands/exists.ts
+++ b/src/commands/exists.ts
@@ -12,10 +12,12 @@ import {
   repoNameToGitUrl
 } from './support/middleware';
 import {Logger, verboseLoggerFactory} from '../util/logger';
+import {defaultBuilder} from './support/builder';
+import {SSLConfig} from './support/model';
 
 export const command = 'exists [gitUrl]'
 export const desc = 'Checks if a hosted git repo exists';
-export const builder = (yargs: Argv<any>) => yargs
+export const builder = (yargs: Argv<any>) => defaultBuilder(yargs)
   .positional('gitUrl', {
     type: 'string',
     description: 'The git url of the git repository that will be deleted',
@@ -75,7 +77,7 @@ export const handler =  async (argv: Arguments<ExistsArgs & {debug?: boolean, ou
 
   Container.bind(Logger).factory(verboseLoggerFactory(argv.debug))
 
-  const credentials = {username: argv.username, password: argv.token}
+  const credentials = {username: argv.username, password: argv.token, caCert: argv.caCert}
 
   try {
     const repoApi: GitApi = await apiFromUrl(argv.gitUrl, credentials)
@@ -116,7 +118,7 @@ export const handler =  async (argv: Arguments<ExistsArgs & {debug?: boolean, ou
   }
 }
 
-interface ExistsArgs {
+interface ExistsArgs extends SSLConfig {
   gitUrl: string;
   username: string;
   token: string;

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -11,11 +11,13 @@ import {
 } from './support/middleware';
 import {forAzureDevOpsProject, forCredentials} from './support/checks';
 import {Logger, verboseLoggerFactory} from '../util/logger';
+import {SSLConfig} from './support/model';
+import {defaultBuilder} from './support/builder';
 
 export const command = 'list [gitUrl]'
 export const aliases = []
 export const desc = 'Lists the hosted git repos for the org or user';
-export const builder = (yargs: Argv<any>) => yargs
+export const builder = (yargs: Argv<any>) => defaultBuilder(yargs)
   .positional('gitUrl', {
     type: 'string',
     description: 'The git url of the org or another repo in the same org. Either gitUrl OR host and owner must be provided.'
@@ -68,7 +70,7 @@ export const handler =  async (argv: Arguments<ListArgs & {debug: boolean, outpu
 
   Container.bind(Logger).factory(verboseLoggerFactory(argv.debug))
 
-  const credentials = {username: argv.username, password: argv.token}
+  const credentials = {username: argv.username, password: argv.token, caCert: argv.caCert}
 
   try {
     const orgApi: GitApi = argv.gitUrl
@@ -99,7 +101,7 @@ export const handler =  async (argv: Arguments<ListArgs & {debug: boolean, outpu
   }
 }
 
-interface ListArgs {
+interface ListArgs extends SSLConfig {
   gitUrl?: string;
   host?: string;
   owner?: string;

--- a/src/commands/pr_cmds/pr-create.ts
+++ b/src/commands/pr_cmds/pr-create.ts
@@ -12,6 +12,8 @@ import {
 } from '../support/middleware';
 import {forAzureDevOpsProject, forCredentials} from '../support/checks';
 import {Logger, verboseLoggerFactory} from '../../util/logger';
+import {SSLConfig} from '../support/model';
+import {defaultBuilder} from '../support/builder';
 
 
 export const forSourceBranch = () => {
@@ -27,7 +29,7 @@ export const forSourceBranch = () => {
 export const command = 'create [gitUrl]'
 export const aliases = []
 export const desc = 'Creates a pull request against hosted git repo';
-export const builder = (yargs: Argv<any>) => yargs
+export const builder = (yargs: Argv<any>) => defaultBuilder(yargs)
   .positional('gitUrl', {
     type: 'string',
     description: 'The url of the repo that will be cloned',
@@ -103,7 +105,7 @@ export const handler =  async (argv: Arguments<CreatePullRequestArgs & {debug: b
 
   Container.bind(Logger).factory(verboseLoggerFactory(argv.debug))
 
-  const credentials = {username: argv.username, password: argv.token}
+  const credentials = {username: argv.username, password: argv.token, caCert: argv.caCert}
 
   try {
     const repoApi: GitApi = await apiFromUrl(argv.gitUrl, credentials)
@@ -174,7 +176,7 @@ export const handler =  async (argv: Arguments<CreatePullRequestArgs & {debug: b
   }
 }
 
-interface CreatePullRequestArgs {
+interface CreatePullRequestArgs extends SSLConfig {
   gitUrl: string;
   sourceBranch: string;
   targetBranch?: string;

--- a/src/commands/pr_cmds/pr-get.ts
+++ b/src/commands/pr_cmds/pr-get.ts
@@ -12,11 +12,13 @@ import {
 } from '../support/middleware';
 import {forAzureDevOpsProject, forCredentials} from '../support/checks';
 import {Logger, verboseLoggerFactory} from '../../util/logger';
+import {SSLConfig} from '../support/model';
+import {defaultBuilder} from '../support/builder';
 
 export const command = 'get [gitUrl]'
 export const aliases = []
 export const desc = 'Gets information about a pull request';
-export const builder = (yargs: Argv<any>) => yargs
+export const builder = (yargs: Argv<any>) => defaultBuilder(yargs)
   .positional('gitUrl', {
     type: 'string',
     description: 'The url of the repo that will be cloned',
@@ -73,7 +75,7 @@ export const handler =  async (argv: Arguments<GetPullRequestArgs & {debug: bool
 
   Container.bind(Logger).factory(verboseLoggerFactory(argv.debug))
 
-  const credentials = {username: argv.username, password: argv.token}
+  const credentials = {username: argv.username, password: argv.token, caCert: argv.caCert}
 
   try {
     const repoApi: GitApi = await apiFromUrl(argv.gitUrl, credentials)
@@ -130,7 +132,7 @@ export const handler =  async (argv: Arguments<GetPullRequestArgs & {debug: bool
   }
 }
 
-interface GetPullRequestArgs {
+interface GetPullRequestArgs extends SSLConfig {
   pullNumber: number;
   gitUrl: string;
   username: string;

--- a/src/commands/pr_cmds/pr-merge.ts
+++ b/src/commands/pr_cmds/pr-merge.ts
@@ -9,7 +9,6 @@ import {
   isGitError,
   MergeMethod,
   MergePullRequestOptions,
-  MergeResolver,
   unionMergeResolver
 } from '../../lib';
 import {
@@ -21,11 +20,13 @@ import {
 } from '../support/middleware';
 import {forAzureDevOpsProject, forCredentials} from '../support/checks';
 import {Logger, verboseLoggerFactory} from '../../util/logger';
+import {SSLConfig} from '../support/model';
+import {defaultBuilder} from '../support/builder';
 
 export const command = 'merge [gitUrl]'
 export const aliases = []
 export const desc = 'Merges a pull request';
-export const builder = (yargs: Argv<any>) => yargs
+export const builder = (yargs: Argv<any>) => defaultBuilder(yargs)
   .positional('gitUrl', {
     type: 'string',
     description: 'The url of the repo with the pull request. The pullNumber can be specified after the hash - e.g. https://github.com/org/repo#pullNumber',
@@ -169,7 +170,7 @@ export const handler =  async (argv: Arguments<MergePullRequestArgs & {debug: bo
   }
 }
 
-interface MergePullRequestArgs {
+interface MergePullRequestArgs extends SSLConfig {
   pullNumber: number;
   gitUrl: string;
   method: MergeMethod;

--- a/src/commands/support/builder.ts
+++ b/src/commands/support/builder.ts
@@ -1,0 +1,14 @@
+import {Argv} from 'yargs';
+import {forCaCertFile} from './checks';
+import {caCertAbsolutePath} from './middleware';
+
+export const defaultBuilder = (yargs: Argv<any>) => {
+  return yargs
+    .option('caCert', {
+      type: 'string',
+      description: 'Name of the file containing the ca certificate for SSL connections',
+      demandOption: false
+    })
+    .middleware(caCertAbsolutePath())
+    .check(forCaCertFile())
+}

--- a/src/commands/support/checks.ts
+++ b/src/commands/support/checks.ts
@@ -1,3 +1,5 @@
+import {fileExists, fileExistsSync} from '../../util/file-util';
+import {SSLConfig} from './model';
 
 export const forCredentials = () => {
   return yargs => {
@@ -16,6 +18,16 @@ export const forAzureDevOpsProject = () => {
   return yargs => {
     if (yargs.host === 'dev.azure.com' && !yargs.project) {
       throw new Error('Git project is required for Azure DevOps repositories.')
+    }
+
+    return true
+  }
+}
+
+export const forCaCertFile = () => {
+  return (yargs: SSLConfig) => {
+    if (yargs.caCert && !fileExistsSync(yargs.caCert)) {
+      throw new Error(`Unable to find caFile: ${yargs.caCert}`)
     }
 
     return true

--- a/src/commands/support/middleware.ts
+++ b/src/commands/support/middleware.ts
@@ -5,6 +5,7 @@ import {load} from 'js-yaml'
 import {Container} from 'typescript-ioc';
 import first from '../../util/first';
 import {Optional} from 'optional-typescript';
+import {SSLConfig} from './model';
 
 export const loadFromEnv = (name: string, envName: string) => {
   return yargs => {
@@ -32,6 +33,7 @@ interface GitCredential {
   host: string
   username: string
   token: string
+  caCert?: string
 }
 
 interface GitConfig {
@@ -58,7 +60,7 @@ export const loadCredentialsFromFile = () => {
         const credential: Optional<GitCredential> = first((config.credentials || []).filter(config => config.host === yargs.host))
 
         return credential
-          .map(cred => ({username: cred.username, token: cred.token}))
+          .map(cred => ({username: cred.username, token: cred.token, caCert: yargs.caCert || cred.caCert}))
           .valueOr({} as any)
       }
     } catch (err) {
@@ -149,5 +151,15 @@ export const parseHostOrgProjectAndBranchFromUrl = () => {
     }
 
     return {}
+  }
+}
+
+export const caCertAbsolutePath = () => {
+  return yargs => {
+    if (yargs.caCert && ! yargs.caCert.startsWith('/')) {
+      return {
+        caCert: join(process.cwd(), yargs.caCert)
+      }
+    }
   }
 }

--- a/src/commands/support/model.ts
+++ b/src/commands/support/model.ts
@@ -1,0 +1,9 @@
+
+export interface SSLConfig {
+  caFile?: string;
+  caCert?: string;
+}
+
+export interface DefaultConfig extends SSLConfig {
+
+}

--- a/src/lib/azure-devops/azure-devops.ts
+++ b/src/lib/azure-devops/azure-devops.ts
@@ -79,7 +79,7 @@ export class AzureDevops extends GitBase<AzureTypedGitRepoConfig> implements Git
     const orgUrl = `https://${this.host}/${this.owner}`;
 
     const authHandler = getPersonalAccessTokenHandler(this.password);
-    const connection = new WebApi(orgUrl, authHandler);
+    const connection = new WebApi(orgUrl, authHandler, {cert: this.caCert});
 
     return connection.getGitApi(orgUrl);
   }

--- a/src/lib/git.model.ts
+++ b/src/lib/git.model.ts
@@ -23,6 +23,7 @@ export interface GitRepoConfig {
   branch?: string;
   username?: string;
   password?: string;
+  caCert?: {cert: string, certFile: string};
 }
 
 export interface AuthGitRepoConfig extends GitRepoConfig {

--- a/src/lib/gitea/index.ts
+++ b/src/lib/gitea/index.ts
@@ -24,7 +24,7 @@ import {
 } from '../git.api';
 import {GitBase} from '../git.base';
 import {BadCredentials, GitRepo, RepoNotFound, TypedGitRepoConfig, Webhook} from '../git.model';
-import {isResponseError} from '../../util/superagent-support';
+import {applyCert, isResponseError} from '../../util/superagent-support';
 
 
 enum GiteaEvent {
@@ -178,29 +178,35 @@ export class Gitea extends GitBase implements GitApi {
   // }
 
   delete(url: string, retryCallback: (err: Error, res: Response) => boolean = defaultRetryCallback): Request {
-    return superagent
+    const req = superagent
       .delete(url)
       .auth(this.username, this.password)
       .set('User-Agent', `${this.username} via ibm-garage-cloud cli`)
       .accept('application/vnd.github.v3+json')
       .retry(10, retryCallback)
+
+    return applyCert(req, this.caCert)
   }
 
   get(url: string, retryCallback: (err: Error, res: Response) => boolean = defaultRetryCallback): Request {
-    return superagent
+    const req = superagent
       .get(url)
       .auth(this.username, this.password)
       .set('User-Agent', `${this.username} via ibm-garage-cloud cli`)
       .accept('application/vnd.github.v3+json')
       .retry(10, retryCallback)
+
+    return applyCert(req, this.caCert)
   }
 
   post(url: string, retryCallback: (err: Error, res: Response) => boolean = defaultRetryCallback): Request {
-    return superagent.post(url)
+    const req = superagent.post(url)
       .auth(this.username, this.password)
       .set('User-Agent', `${this.username} via ibm-garage-cloud cli`)
       .accept('application/vnd.github.v3+json')
       .retry(10, retryCallback)
+
+    return applyCert(req, this.caCert)
   }
 
   async deleteBranch({branch}: DeleteBranchOptions): Promise<string> {

--- a/src/util/ca-cert.ts
+++ b/src/util/ca-cert.ts
@@ -1,0 +1,17 @@
+import {promises} from 'fs';
+
+export const loadCaCert = async (caCert: {cert: string, certFile} | string): Promise<{cert: string, certFile: string} | undefined> => {
+  if (!caCert) {
+    return
+  }
+
+  if (typeof caCert !== 'string') {
+    return caCert
+  }
+
+  const certFile = caCert
+
+  const contents = await promises.readFile(certFile)
+
+  return {cert: contents.toString(), certFile}
+}

--- a/src/util/file-util.ts
+++ b/src/util/file-util.ts
@@ -73,3 +73,12 @@ export const fileContains = async (path: string, contents: string): Promise<bool
 export const fileExists = async (path: string): Promise<boolean> => {
   return await fs.access(path, fs.constants.R_OK).then(v => true).catch(err => false);
 }
+
+export const fileExistsSync = (path: string): boolean => {
+  try {
+    fs.accessSync(path, fs.constants.R_OK)
+    return true
+  } catch (err) {
+    return false
+  }
+}

--- a/src/util/superagent-support.ts
+++ b/src/util/superagent-support.ts
@@ -1,3 +1,4 @@
+import {Request} from 'superagent';
 
 export interface ResponseError extends Error {
   status: number;
@@ -13,4 +14,13 @@ export interface ResponseError extends Error {
 
 export function isResponseError(error: Error): error is ResponseError {
   return error && !!((error as ResponseError).status) && !!((error as ResponseError).response);
+}
+
+export const applyCert = (req: Request, caCert?: {cert: string}): Request => {
+  if (caCert) {
+    // TODO why does CA Cert not work!?!?!
+    return req.ca(caCert.cert).disableTLSCerts()
+  }
+
+  return req
 }


### PR DESCRIPTION
- Adds caCert input parameter to all command-line commands
- Adds cert value to credentials object for apiFromUrl() function and configuration object for apis
- Injects ca cert into superagent request if provided
- Adds http.sslCAInfo config parameter for git clone if provided

closes #119

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>